### PR TITLE
fix: use correct zone.js version

### DIFF
--- a/packages/nx/src/utils/versions.ts
+++ b/packages/nx/src/utils/versions.ts
@@ -10,4 +10,4 @@ export const nodeSassVersion = '^4.14.0';
 export const nsAngularVersion = '~11.0.0';
 export const nsNgToolsVersion = '~11.0.0';
 export const nsRxjs = '~6.5.5';
-export const nsZonejs = '^0.10.2"';
+export const nsZonejs = '~0.10.2';


### PR DESCRIPTION
This patch fixes the error that I got when running this

```
$ npx nx g @nativescript/nx:app mobile --framework angular
⠼ Installing packages (yarn)...error Couldn't find any versions for "zone.js" that matches "^0.11.1\""
✖ Package install failed, see above.
UnsuccessfulWorkflowExecution [Error]: Workflow did not execute successfully.
    at ChildProcess.<anonymous> (/Users/beeman/sandbox/ns-nx-app/node_modules/@angular-devkit/schematics/tasks/package-manager/executor.js:109:31)
    at ChildProcess.emit (events.js:315:20)
    at maybeClose (internal/child_process.js:1048:16)
    at Socket.<anonymous> (internal/child_process.js:439:11)
    at Socket.emit (events.js:315:20)
    at Pipe.<anonymous> (net.js:673:12)
The generator workflow failed. See above.
```