### PR TITLE
fix: android run task binded to ios

### DIFF
--- a/packages/nx/src/schematics/application/application.ts
+++ b/packages/nx/src/schematics/application/application.ts
@@ -81,7 +81,7 @@ export default function (options: Schema) {
             android: {
               builder: '@nativescript/nx:build',
               options: {
-                platform: 'ios',
+                platform: 'android',
               },
               configurations: {
                 prod: {


### PR DESCRIPTION
When running `nx run <app-name>:android` i was getting `Applications for platform iOS can not be built on this OS` error.
Seems like android builder config was targeting the platform to ios, changing this option to android fixed it.