### PR TITLE
Support for `nx run nativescript-app:build`

### DIFF
--- a/packages/nx/src/builders/build/builder.ts
+++ b/packages/nx/src/builders/build/builder.ts
@@ -6,7 +6,7 @@ export function runBuilder(options: BuildBuilderSchema, context: ExecutorContext
   return new Promise((resolve, reject) => {
     const projectConfig = context.workspace.projects[context.projectName];
     // determine if running or building only
-    const isBuild = process.argv.find((a) => a === 'build');
+    const isBuild = process.argv.find((a) => a === 'build' || a.endsWith(":build"));
     if (isBuild) {
       // allow build options to override run target options
       const buildTarget = projectConfig.targets['build'];


### PR DESCRIPTION
You can trigger a build via `nx build TARGET` or `nx run TARGET:build`. The latter is also being used if you run `nx affected:build` or something like `nx run-many --target build --all --prod --with-deps`. This would set `isBuild` to false.