### PR TITLE
fix: allow --force to be optional

### DIFF
--- a/packages/nx/src/builders/build/builder.ts
+++ b/packages/nx/src/builders/build/builder.ts
@@ -156,14 +156,16 @@ export function runBuilder(options: BuildBuilderSchema, context: ExecutorContext
         nsOptions.push('--copy-to');
         nsOptions.push(options.copyTo);
       }
- 
+
       if (fileReplacements.length) {
         // console.log('fileReplacements:', fileReplacements);
         nsOptions.push('--env.replace');
         nsOptions.push(fileReplacements.join(','));
       }
-      // always add --force for now since within Nx we use @nativescript/webpack at root only and the {N} cli shows a blocking error if not within the app
-      nsOptions.push('--force');
+      // always add --force (unless explicity set to false) for now since within Nx we use @nativescript/webpack at root only and the {N} cli shows a blocking error if not within the app
+      if (options?.force !== false) {
+        nsOptions.push('--force');
+      }
     }
     // console.log('command:', [`ns`, ...nsOptions, ...additionalCliFlagArgs].join(' '));
     // console.log('command:', [`ns`, ...nsOptions].join(' '));

--- a/packages/nx/src/builders/build/schema.d.ts
+++ b/packages/nx/src/builders/build/schema.d.ts
@@ -13,6 +13,7 @@ export interface BuildBuilderSchema extends JsonObject {
   production?: boolean;
   platform?: 'ios' | 'android';
   copyTo?: string;
+  force?: boolean;
 
   // ios only
   provision?: string;
@@ -23,4 +24,4 @@ export interface BuildBuilderSchema extends JsonObject {
   keyStorePassword?: string;
   keyStoreAlias?: string;
   keyStoreAliasPassword?: string;
-} 
+}

--- a/packages/nx/src/builders/build/schema.json
+++ b/packages/nx/src/builders/build/schema.json
@@ -86,6 +86,11 @@
       "type": "boolean",
       "default": false,
       "description": "Do a full project clean"
+    },
+    "force": {
+      "type": "boolean",
+      "default": true,
+      "description": "If true, skips the application compatibility checks and forces npm i to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring ns migrate."
     }
   },
   "required": []


### PR DESCRIPTION
This PR adds the `force` option that allows disabling the default behavior of always adding the `--force` flag to every NativeScript build/run command.
I saw the below note, but there are some edge cases where running `npm i` is not desirable or problematic.
> always add --force for now since within Nx we use @nativescript/webpack at root only and the {N} cli shows a blocking error if not within the app

This commit still leaves the current behavior of adding `--force` by default but allows disabling the `--force` flag by explictly setting the new `force` option to `false`.

Example
```json
"options": {
    "platform": "android",
    "noHmr": true,
    "force": false
},
```