### PR TITLE
feat: add ns prepare as an option

### DIFF
--- a/packages/nx/src/builders/build/builder.ts
+++ b/packages/nx/src/builders/build/builder.ts
@@ -92,6 +92,8 @@ export function runBuilder(options: BuildBuilderSchema, context: ExecutorContext
     } else {
       if (isBuild) {
         nsOptions.push('build');
+      } else if (options.prepare) {
+        nsOptions.push('prepare');
       } else {
         if (options.debug === false) {
           nsOptions.push('run');
@@ -156,7 +158,7 @@ export function runBuilder(options: BuildBuilderSchema, context: ExecutorContext
         nsOptions.push('--copy-to');
         nsOptions.push(options.copyTo);
       }
- 
+
       if (fileReplacements.length) {
         // console.log('fileReplacements:', fileReplacements);
         nsOptions.push('--env.replace');

--- a/packages/nx/src/builders/build/schema.d.ts
+++ b/packages/nx/src/builders/build/schema.d.ts
@@ -13,6 +13,8 @@ export interface BuildBuilderSchema extends JsonObject {
   production?: boolean;
   platform?: 'ios' | 'android';
   copyTo?: string;
+  /** For running `ns prepare <platform>` */
+  prepare:? boolean;
 
   // ios only
   provision?: string;
@@ -23,4 +25,4 @@ export interface BuildBuilderSchema extends JsonObject {
   keyStorePassword?: string;
   keyStoreAlias?: string;
   keyStoreAliasPassword?: string;
-} 
+}

--- a/packages/nx/src/builders/build/schema.json
+++ b/packages/nx/src/builders/build/schema.json
@@ -57,6 +57,11 @@
       "type": "string",
       "description": "When building, copy the package to this location."
     },
+    "prepare:": {
+      "type": "boolean",
+      "description": "Starts a Webpack compilation and prepares the app's App_Resources and the plugins platforms directories. The output is generated in a subdirectory for the selected target platform in the platforms directory. This lets you build the project for the selected platform.",
+      "default": false
+    },
     "provision": {
       "type": "string",
       "description": "(iOS Only) When building, use this provision profile name."


### PR DESCRIPTION
This commit adds the option `prepare` which, when set to `true`, allows running the `ns prepare <platform> [options]` command. The default is `false`.