### PR TITLE
fix: windows node spawn einval error

### DIFF
--- a/packages/nx/src/utils/executors.ts
+++ b/packages/nx/src/utils/executors.ts
@@ -272,6 +272,7 @@ export function commonExecutor(options: BuildExecutorSchema | TestExecutorSchema
         const child = childProcess.spawn(/^win/.test(process.platform) ? 'ns.cmd' : 'ns', [...nsOptions, ...additionalArgs], {
           cwd: projectCwd,
           stdio: 'inherit',
+          shell: process.platform === 'win32',
         });
         child.on('close', (code) => {
           console.log(`Done.`);
@@ -284,6 +285,7 @@ export function commonExecutor(options: BuildExecutorSchema | TestExecutorSchema
         return new Promise((resolve) => {
           const child = childProcess.spawn(/^win/.test(process.platform) ? 'ns.cmd' : 'ns', ['config', 'get', `id`], {
             cwd: projectCwd,
+            shell: process.platform === 'win32',
           });
           child.stdout.setEncoding('utf8');
           child.stdout.on('data', function (data) {
@@ -307,6 +309,7 @@ export function commonExecutor(options: BuildExecutorSchema | TestExecutorSchema
               const child = childProcess.spawn(/^win/.test(process.platform) ? 'ns.cmd' : 'ns', ['config', 'set', `${options.platform}.id`, options.id], {
                 cwd: projectCwd,
                 stdio: 'inherit',
+                shell: process.platform === 'win32',
               });
               child.on('close', (code) => {
                 child.kill('SIGKILL');

--- a/packages/nx/src/utils/helpers.ts
+++ b/packages/nx/src/utils/helpers.ts
@@ -733,3 +733,29 @@ export namespace PluginFeatureHelpers {
     return moveTo;
   }
 }
+
+// Copied from: https://github.com/NativeScript/nativescript-cli/blob/16064affee98c837e8cbe0865254dcb5b81f0bbe/lib/common/helpers.ts#L246C1-L268C2
+// For https://github.com/NativeScript/nativescript-cli/pull/5808
+function bashQuote(s: string): string {
+  if (s[0] === "'" && s[s.length - 1] === "'") {
+    return s;
+  }
+  // replace ' with '"'"' and wrap in ''
+  return "'" + s.replace(/'/g, "'\"'\"'") + "'";
+}
+
+function cmdQuote(s: string): string {
+  if (s[0] === '"' && s[s.length - 1] === '"') {
+    return s;
+  }
+  // replace " with \" and wrap in ""
+  return '"' + s.replace(/"/g, '\\"') + '"';
+}
+
+export function quoteString(s: string): string {
+  if (!s) {
+    return s;
+  }
+
+  return process.platform === 'win32' ? cmdQuote(s) : bashQuote(s);
+}


### PR DESCRIPTION
All commands fail to run on Windows with newer Node versions with `Error: spawn EINVAL` due to https://github.com/nodejs/node/commit/69ffc6d50dbd9d7d0257f5b9b403026e1aa205ee.  This commit adds `shell: true` to all the `spawn` calls when the platform is Windows.

This is similar to https://github.com/NativeScript/NativeScript/issues/10532